### PR TITLE
fix(styles): applies nb-for-theme mixin when cssCustomProperties mode…

### DIFF
--- a/src/framework/theme/styles/core/theming/_install.scss
+++ b/src/framework/theme/styles/core/theming/_install.scss
@@ -11,8 +11,18 @@
 @use 'register';
 
 @mixin nb-for-theme($name) {
-  @if (theming-variables.$nb-theme-name == $name) {
-    @content;
+  @if (theming-variables.$nb-enable-css-custom-properties) {
+    @each $theme-name in register.nb-get-enabled-themes() {
+      @if ($theme-name == $name) {
+        .nb-theme-#{$theme-name} {
+          @content;
+        }
+      }
+    }
+  } @else {
+    @if (theming-variables.$nb-theme-name == $name) {
+      @content;
+    }
   }
 }
 


### PR DESCRIPTION
… is enabled (#3183)

### Please read and mark the following check list before creating a pull request:

- [] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.

#### Short description of what this resolves:
